### PR TITLE
[FIX] 대댓글의 대댓글 작성 API 로직 수정

### DIFF
--- a/src/main/java/com/jida/service/CommentServiceImpl.java
+++ b/src/main/java/com/jida/service/CommentServiceImpl.java
@@ -34,11 +34,11 @@ public class CommentServiceImpl implements CommentService {
 
         //대댓글
         if (parentId != null) {
-            commentMapper.findById(parentId)
+            Comment comment = commentMapper.findById(parentId)
                     .orElseThrow(() -> new CustomException(COMMENT_NOT_FOUND));
-            //대댓글에는 대댓글 불가능
-            if (commentMapper.findById(parentId).get().getParentId() != null) {
-                throw new CustomException(RE_COMMENT_ONLY);
+            //대댓글에 대댓글 작성 시 최상위 부모를 부모로 지정
+            if(comment.getParentId() != null) {
+                parentId = comment.getParentId();
             }
         }
 


### PR DESCRIPTION
대댓글에 대댓글을 작성 시 최상위 댓글의 대댓글로 함.
즉, 하나의 댓글에 여러 대댓글만 달린다고 생각하면 됩니다.

closed #48 