### PR TITLE
[FEAT, FIX] 쪽지 전송, 답장 API & 토큰 관련 수정

### DIFF
--- a/src/main/java/com/jida/constants/SuccessCode.java
+++ b/src/main/java/com/jida/constants/SuccessCode.java
@@ -29,7 +29,12 @@ public enum SuccessCode {
 	SCRAP_READ_SUCCESS(OK, "스크랩 전체 조회를 성공했습니다."),
 	COMMENT_SAVE_SUCCESS(OK, "댓글 저장을 완료했습니다."),
 	COMMENT_LIST_SUCCESS(OK, "댓글 조회를 성공했습니다."),
-	COMMENT_DELETE_SUCCESS(OK, "댓글 삭제를 성공했습니다.");
+	COMMENT_DELETE_SUCCESS(OK, "댓글 삭제를 성공했습니다."),
+
+	//Message
+	MESSAGE_SEND_SUCCESS(OK, "메시지 전송에 성공했습니다."),
+	MESSAGE_REPLY_SUCCESS(OK, "메시지 답장에 성공했습니다.");
+
 
 	private final HttpStatus status;
 	private final String message;

--- a/src/main/java/com/jida/controller/MemberController.java
+++ b/src/main/java/com/jida/controller/MemberController.java
@@ -91,7 +91,7 @@ public class MemberController {
 			log.info("사용 가능한 토큰!!!");
 			try {
 //				로그인 사용자 정보.
-				MemberDetailResponseDto memberDetailResponseDto = memberService.findById(userId);
+				MemberDetailResponseDto memberDetailResponseDto = memberService.findByCustomId(userId);
 				resultMap.put("userInfo", memberDetailResponseDto);
 				status = HttpStatus.OK;
 			} catch (Exception e) {

--- a/src/main/java/com/jida/controller/MessageController.java
+++ b/src/main/java/com/jida/controller/MessageController.java
@@ -1,2 +1,38 @@
-package com.jida.controller;public class MessageController {
+package com.jida.controller;
+
+import static com.jida.constants.SuccessCode.MESSAGE_REPLY_SUCCESS;
+import static com.jida.constants.SuccessCode.MESSAGE_SEND_SUCCESS;
+import com.jida.dto.req.MessageRequestDto;
+import com.jida.dto.res.message.MessageResponse;
+import com.jida.dto.res.message.MessageSendResponse;
+import com.jida.dto.res.message.MessageSendResponseDto;
+import com.jida.service.MemberService;
+import com.jida.service.MessageService;
+import com.jida.util.JWTUtil;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/message")
+public class MessageController {
+    private final MessageService messageService;
+    private final JWTUtil jwtUtil;
+    @PostMapping("/send/{memberId}")
+    public ResponseEntity<MessageSendResponse> sendMessage(@Valid @RequestBody MessageRequestDto messageRequestDto, @PathVariable long memberId, HttpServletRequest request){
+        long sendMemberId = jwtUtil.getUserId(request.getHeader("Authorization"));
+        MessageSendResponseDto response = messageService.sendMessage(messageRequestDto, sendMemberId, memberId);
+        return MessageSendResponse.newResponse(MESSAGE_SEND_SUCCESS, response);
+    }
+
+    @PostMapping("/room/{roomId}")
+    public ResponseEntity<MessageResponse> replyMessage(@Valid @RequestBody MessageRequestDto messageRequestDto, @PathVariable long roomId, HttpServletRequest request){
+        long sendMemberId = jwtUtil.getUserId(request.getHeader("Authorization"));
+        messageService.replyMessage(messageRequestDto, roomId, sendMemberId);
+        return MessageResponse.newResponse(MESSAGE_REPLY_SUCCESS);
+    }
+
 }

--- a/src/main/java/com/jida/controller/MessageController.java
+++ b/src/main/java/com/jida/controller/MessageController.java
@@ -1,0 +1,2 @@
+package com.jida.controller;public class MessageController {
+}

--- a/src/main/java/com/jida/controller/PostController.java
+++ b/src/main/java/com/jida/controller/PostController.java
@@ -43,8 +43,8 @@ public class PostController {
 
     @PostMapping
     public ResponseEntity<PostDetailResponse> savePost(@RequestBody PostSaveRequestDto postSaveRequestDto, HttpServletRequest request) {
-        String id = jwtUtil.getUserId(request.getHeader("Authorization"));
-        long postId = postService.writePost(id,postSaveRequestDto);
+        long memberId = jwtUtil.getUserId(request.getHeader("Authorization"));
+        long postId = postService.writePost(memberId,postSaveRequestDto);
         PostDetailResponseDto responseDto = postService.viewPost(postId);
 
         return PostDetailResponse.newResponse(POST_SAVE_SUCCESS, responseDto);

--- a/src/main/java/com/jida/domain/Member.java
+++ b/src/main/java/com/jida/domain/Member.java
@@ -25,15 +25,4 @@ public class Member {
 		return member;
 	}
 
-	public static Member detailToMember(MemberDetailResponseDto memberDetailResponseDto){
-		Member member = new Member();
-		member.memberId = memberDetailResponseDto.getMemberId();
-		member.id = memberDetailResponseDto.getId();
-		member.password = memberDetailResponseDto.getPassword();
-		member.nickname = memberDetailResponseDto.getNickname();
-		member.email = memberDetailResponseDto.getEmail();
-		member.refreshToken = memberDetailResponseDto.getRefreshToken();
-		return member;
-	}
-
 }

--- a/src/main/java/com/jida/domain/Message.java
+++ b/src/main/java/com/jida/domain/Message.java
@@ -1,2 +1,24 @@
-package com.jida.domain;public class Message {
+package com.jida.domain;
+
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class Message {
+    private long messageId;
+    private MessageRoom messageRoom;
+    private Member member;
+    private String content;
+    private String createdAt;
+
+    public static Message createMessage(MessageRoom messageRoom, Member member, String content){
+        Message message = new Message();
+        message.messageRoom = messageRoom;
+        message.member = member;
+        message.content = content;
+        return message;
+    }
+
 }

--- a/src/main/java/com/jida/domain/Message.java
+++ b/src/main/java/com/jida/domain/Message.java
@@ -1,0 +1,2 @@
+package com.jida.domain;public class Message {
+}

--- a/src/main/java/com/jida/domain/MessageRoom.java
+++ b/src/main/java/com/jida/domain/MessageRoom.java
@@ -1,0 +1,2 @@
+package com.jida.domain;public class MessageRoom {
+}

--- a/src/main/java/com/jida/domain/MessageRoom.java
+++ b/src/main/java/com/jida/domain/MessageRoom.java
@@ -1,2 +1,21 @@
-package com.jida.domain;public class MessageRoom {
+package com.jida.domain;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MessageRoom {
+    private long roomId;
+    private Member sender;
+    private Member receiver;
+    private String createdAt;
+
+    public static MessageRoom createMessageRoom(Member sender, Member receiver){
+        MessageRoom messageRoom = new MessageRoom();
+        messageRoom.sender = sender;
+        messageRoom.receiver = receiver;
+        return messageRoom;
+    }
+
 }

--- a/src/main/java/com/jida/dto/req/MessageRequestDto.java
+++ b/src/main/java/com/jida/dto/req/MessageRequestDto.java
@@ -1,2 +1,8 @@
-package com.jida.dto.req;public class MessageRequestDto {
+package com.jida.dto.req;
+
+import lombok.Getter;
+
+@Getter
+public class MessageRequestDto {
+    private String content;
 }

--- a/src/main/java/com/jida/dto/req/MessageRequestDto.java
+++ b/src/main/java/com/jida/dto/req/MessageRequestDto.java
@@ -1,0 +1,2 @@
+package com.jida.dto.req;public class MessageRequestDto {
+}

--- a/src/main/java/com/jida/dto/res/message/MessageResponse.java
+++ b/src/main/java/com/jida/dto/res/message/MessageResponse.java
@@ -1,0 +1,2 @@
+package com.jida.dto.res.message;public class MessageResponse {
+}

--- a/src/main/java/com/jida/dto/res/message/MessageResponse.java
+++ b/src/main/java/com/jida/dto/res/message/MessageResponse.java
@@ -1,2 +1,17 @@
-package com.jida.dto.res.message;public class MessageResponse {
+package com.jida.dto.res.message;
+
+import com.jida.constants.SuccessCode;
+import com.jida.dto.BaseResponse;
+import org.springframework.http.ResponseEntity;
+
+public class MessageResponse extends BaseResponse {
+    private MessageResponse(Boolean success, String message){
+        super(success, message);
+    }
+    public static MessageResponse of(Boolean success, String message){
+        return new MessageResponse(success, message);
+    }
+    public static ResponseEntity<MessageResponse> newResponse(SuccessCode code){
+        return new ResponseEntity<>(MessageResponse.of(true, code.getMessage()), code.getStatus());
+    }
 }

--- a/src/main/java/com/jida/dto/res/message/MessageSendResponse.java
+++ b/src/main/java/com/jida/dto/res/message/MessageSendResponse.java
@@ -1,2 +1,25 @@
-package com.jida.dto.res.message;public class MessageSendResponse {
+package com.jida.dto.res.message;
+
+import com.jida.constants.SuccessCode;
+import com.jida.dto.BaseResponse;
+import lombok.Getter;
+import org.springframework.http.ResponseEntity;
+
+@Getter
+public class MessageSendResponse extends BaseResponse {
+    private MessageSendResponseDto data;
+
+    private MessageSendResponse(Boolean success, String message, MessageSendResponseDto data){
+        super(success, message);
+        this.data = data;
+    }
+    public static MessageSendResponse of(Boolean success, String message, MessageSendResponseDto data){
+        return new MessageSendResponse(success, message, data);
+    }
+    public static ResponseEntity<MessageSendResponse> newResponse(SuccessCode code, MessageSendResponseDto data){
+        MessageSendResponse response = MessageSendResponse.of(true, code.getMessage(), data);
+        return new ResponseEntity<>(response, code.getStatus());
+    }
+
+
 }

--- a/src/main/java/com/jida/dto/res/message/MessageSendResponse.java
+++ b/src/main/java/com/jida/dto/res/message/MessageSendResponse.java
@@ -1,0 +1,2 @@
+package com.jida.dto.res.message;public class MessageSendResponse {
+}

--- a/src/main/java/com/jida/dto/res/message/MessageSendResponseDto.java
+++ b/src/main/java/com/jida/dto/res/message/MessageSendResponseDto.java
@@ -1,2 +1,14 @@
-package com.jida.dto.res.message;public class MessageSendResponseDto {
+package com.jida.dto.res.message;
+
+import lombok.Getter;
+
+@Getter
+public class MessageSendResponseDto {
+    long roomId;
+    private MessageSendResponseDto(long roomId){
+        this.roomId = roomId;
+    }
+    public static MessageSendResponseDto of(long roomId) {
+        return new MessageSendResponseDto(roomId);
+    }
 }

--- a/src/main/java/com/jida/dto/res/message/MessageSendResponseDto.java
+++ b/src/main/java/com/jida/dto/res/message/MessageSendResponseDto.java
@@ -1,0 +1,2 @@
+package com.jida.dto.res.message;public class MessageSendResponseDto {
+}

--- a/src/main/java/com/jida/mapper/MemberMapper.java
+++ b/src/main/java/com/jida/mapper/MemberMapper.java
@@ -13,9 +13,11 @@ import java.util.Optional;
 @Mapper
 public interface MemberMapper {
 	Member loginMember(Map<String, String> map);
+	Member findById(long memberId); //pk로 찾기
 	void joinMember(Member member);
-	Member findById(String id);
+	Member findByCustomId(String id); //아이디로 찾기
 	void saveRefreshToken(Map<String, String> map);
 	Object getRefreshToken(String id);
 	void deleteRefreshToken(Map<String, String> map);
+	long memberIdById(String id); //아이디를 pk로 변환
 }

--- a/src/main/java/com/jida/mapper/MessageMapper.java
+++ b/src/main/java/com/jida/mapper/MessageMapper.java
@@ -1,2 +1,9 @@
-package com.jida.mapper;public interface MessageMapper {
+package com.jida.mapper;
+
+import com.jida.domain.Message;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface MessageMapper {
+    void saveMessage(Message message);
 }

--- a/src/main/java/com/jida/mapper/MessageMapper.java
+++ b/src/main/java/com/jida/mapper/MessageMapper.java
@@ -1,0 +1,2 @@
+package com.jida.mapper;public interface MessageMapper {
+}

--- a/src/main/java/com/jida/mapper/MessageRoomMapper.java
+++ b/src/main/java/com/jida/mapper/MessageRoomMapper.java
@@ -1,0 +1,2 @@
+package com.jida.mapper;public interface MessageRoomMapper {
+}

--- a/src/main/java/com/jida/mapper/MessageRoomMapper.java
+++ b/src/main/java/com/jida/mapper/MessageRoomMapper.java
@@ -1,2 +1,16 @@
-package com.jida.mapper;public interface MessageRoomMapper {
+package com.jida.mapper;
+
+import com.jida.domain.Member;
+import com.jida.domain.MessageRoom;
+import org.apache.ibatis.annotations.Mapper;
+
+import java.util.List;
+import java.util.Optional;
+
+@Mapper
+public interface MessageRoomMapper {
+    void saveMessageRoom(MessageRoom messageRoom);
+    MessageRoom findById(long roomId);
+    Optional<MessageRoom> findByMembers(long sendMemberId, long receiveMemberId);
+    //List<MessageRoom> findByMember(long memberId);
 }

--- a/src/main/java/com/jida/service/MemberService.java
+++ b/src/main/java/com/jida/service/MemberService.java
@@ -9,7 +9,7 @@ import com.jida.dto.res.member.MemberDetailResponseDto;
 public interface MemberService {
 	void joinMember(MemberSaveRequestDto memberSaveRequestDto);
 	MemberDetailResponseDto loginMember(MemberRequestDto memberRequestDto);
-	MemberDetailResponseDto findById(String memberId);
+	MemberDetailResponseDto findByCustomId(String memberId);
 	void saveRefreshToken(String memberId, String refreshToken);
 	Object getRefreshToken(String memberId) throws Exception;
 	void deleteRefreshToken(String memberId) throws Exception;

--- a/src/main/java/com/jida/service/MemberServiceImpl.java
+++ b/src/main/java/com/jida/service/MemberServiceImpl.java
@@ -35,8 +35,8 @@ public class MemberServiceImpl implements MemberService {
     }
 
 	@Override
-	public MemberDetailResponseDto findById(String memberId) {
-		Member member = memberMapper.findById(memberId);
+	public MemberDetailResponseDto findByCustomId(String id) {
+		Member member = memberMapper.findByCustomId(id);
 		return MemberDetailResponseDto.of(member);
 	}
 

--- a/src/main/java/com/jida/service/MessageService.java
+++ b/src/main/java/com/jida/service/MessageService.java
@@ -1,0 +1,2 @@
+package com.jida.service;public interface MessageService {
+}

--- a/src/main/java/com/jida/service/MessageService.java
+++ b/src/main/java/com/jida/service/MessageService.java
@@ -1,2 +1,10 @@
-package com.jida.service;public interface MessageService {
+package com.jida.service;
+
+import com.jida.dto.req.MessageRequestDto;
+import com.jida.dto.res.message.MessageSendResponseDto;
+import com.jida.mapper.MemberMapper;
+
+public interface MessageService {
+    MessageSendResponseDto sendMessage(MessageRequestDto messageRequestDto, long sendMemberId, long receiveMemberId);
+    void replyMessage(MessageRequestDto messageRequestDto, long roomId, long sendMemberId);
 }

--- a/src/main/java/com/jida/service/MessageServiceImpl.java
+++ b/src/main/java/com/jida/service/MessageServiceImpl.java
@@ -1,0 +1,2 @@
+package com.jida.service;public class MessageServiceImpl {
+}

--- a/src/main/java/com/jida/service/MessageServiceImpl.java
+++ b/src/main/java/com/jida/service/MessageServiceImpl.java
@@ -1,2 +1,53 @@
-package com.jida.service;public class MessageServiceImpl {
+package com.jida.service;
+
+import com.jida.domain.Member;
+import com.jida.domain.Message;
+import com.jida.domain.MessageRoom;
+import com.jida.dto.req.MessageRequestDto;
+import com.jida.dto.res.message.MessageSendResponseDto;
+import com.jida.mapper.MemberMapper;
+import com.jida.mapper.MessageMapper;
+import com.jida.mapper.MessageRoomMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MessageServiceImpl implements MessageService{
+    private final MemberMapper memberMapper;
+    private final MessageMapper messageMapper;
+    private final MessageRoomMapper messageRoomMapper;
+    @Override
+    public MessageSendResponseDto sendMessage(MessageRequestDto messageRequestDto, long sendMemberId, long receiveMemberId) {
+        Member sendMember = memberMapper.findById(sendMemberId);
+        Member receiveMember = memberMapper.findById(receiveMemberId);
+        Optional<MessageRoom> messageRoom = messageRoomMapper.findByMembers(sendMember.getMemberId(), receiveMember.getMemberId());
+        MessageRoom room;
+        if(messageRoom.isEmpty()){
+            MessageRoom createdMessageRoom = MessageRoom.createMessageRoom(sendMember, receiveMember);
+
+            messageRoomMapper.saveMessageRoom(createdMessageRoom);
+            room = createdMessageRoom;
+            log.info("Roomid = {}", room.getRoomId());
+        }
+        else{
+            room = messageRoom.get();
+        }
+        Message message = Message.createMessage(room, sendMember, messageRequestDto.getContent());
+        messageMapper.saveMessage(message);
+        return MessageSendResponseDto.of(room.getRoomId());
+    }
+
+    @Override
+    public void replyMessage(MessageRequestDto messageRequestDto, long roomId, long sendMemberId) {
+       Member member = memberMapper.findById(sendMemberId);
+       MessageRoom messageRoom = messageRoomMapper.findById(roomId);
+       Message message = Message.createMessage(messageRoom, member, messageRequestDto.getContent());
+       messageMapper.saveMessage(message);
+    }
 }

--- a/src/main/java/com/jida/service/PostService.java
+++ b/src/main/java/com/jida/service/PostService.java
@@ -11,7 +11,7 @@ import com.jida.dto.res.post.PostDetailResponseDto;
 
 public interface PostService {
 	PostListResponseDto showList(String order, long boardId, int pageIndex, int pageSize);
-	long writePost(String id, PostSaveRequestDto postSaveRequestDto);
+	long writePost(long memberId, PostSaveRequestDto postSaveRequestDto);
 	void updateHit(long postId);
 	PostDetailResponseDto viewPost(long postId);
 	long modifyPost(long postId, PostSaveRequestDto postSaveRequestDto);

--- a/src/main/java/com/jida/service/PostServiceImpl.java
+++ b/src/main/java/com/jida/service/PostServiceImpl.java
@@ -10,8 +10,8 @@ import com.jida.dto.res.board.BoardListResponseDto.BoardList;
 import com.jida.dto.res.post.PostListResponseDto;
 import com.jida.dto.res.post.PostListResponseDto.PostList;
 import com.jida.exception.CustomException;
-import com.jida.mapper.PostLikeMapper;
-import com.jida.mapper.PostScrapMapper;
+import com.jida.mapper.*;
+
 import java.util.List;
 
 import java.util.Optional;
@@ -23,8 +23,6 @@ import com.jida.domain.Post;
 import com.jida.dto.req.PostSaveRequestDto;
 import com.jida.dto.res.post.PostDetailResponseDto;
 import com.jida.dto.res.post.PostDetailResponseDto.PostDetail;
-import com.jida.mapper.BoardMapper;
-import com.jida.mapper.PostMapper;
 
 import lombok.RequiredArgsConstructor;
 
@@ -34,9 +32,9 @@ public class PostServiceImpl implements PostService {
 	
 	private final PostMapper postMapper;
 	private final BoardMapper boardMapper;
+	private final MemberMapper memberMapper;
 	private final PostLikeMapper postLikeMapper;
 	private final PostScrapMapper postScrapMapper;
-	private final MemberService memberService;
 
 	//TODO: 예외 처리 및 Optional 처리
 	@Override
@@ -50,9 +48,9 @@ public class PostServiceImpl implements PostService {
 	}
 
 	@Override
-	public long writePost(String id, PostSaveRequestDto postSaveRequestDto) {
+	public long writePost(long memberId, PostSaveRequestDto postSaveRequestDto) {
 		Board board = boardMapper.findById(postSaveRequestDto.getBoardName());
-		Member member = Member.detailToMember(memberService.findById(id));
+		Member member = memberMapper.findById(memberId);
 		Post post = Post.creatPost(member, board, postSaveRequestDto.getTitle(), postSaveRequestDto.getContent());
 		postMapper.writePost(post);
 		

--- a/src/main/java/com/jida/util/JWTUtil.java
+++ b/src/main/java/com/jida/util/JWTUtil.java
@@ -4,6 +4,8 @@ import java.io.UnsupportedEncodingException;
 import java.util.Date;
 import java.util.Map;
 
+import com.jida.mapper.MemberMapper;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -27,6 +29,13 @@ public class JWTUtil {
 
     @Value("${jwt.refresh-token.expiretime}")
     private long refreshTokenExpireTime;
+
+    private final MemberMapper memberMapper;
+
+    @Autowired
+    public JWTUtil(MemberMapper memberMapper) {
+        this.memberMapper = memberMapper;
+    }
 
     public String createAccessToken(String userId) {
         return create(userId, "access-token", accessTokenExpireTime);
@@ -97,7 +106,7 @@ public class JWTUtil {
         }
     }
 
-    public String getUserId(String authorization) {
+    public long getUserId(String authorization) {
         Jws<Claims> claims = null;
         try {
             claims = Jwts.parser().setSigningKey(this.generateKey()).parseClaimsJws(authorization);
@@ -107,7 +116,8 @@ public class JWTUtil {
         }
         Map<String, Object> value = claims.getBody();
         log.info("value : {}", value);
-        return (String) value.get("userId");
+        String id = (String) value.get("userId");
+        return memberMapper.memberIdById(id);
     }
 
 }

--- a/src/main/resources/mapper/member.xml
+++ b/src/main/resources/mapper/member.xml
@@ -19,7 +19,13 @@
 		where id = #{id} and password = #{password}
 	</select>
 
-	<select id="findById" parameterType="string" resultMap="member">
+	<select id="findById" parameterType="long" resultMap="member">
+		select *
+		from member
+		where member_id=#{memberId}
+	</select>
+
+	<select id="findByCustomId" parameterType="string" resultMap="member">
 		select *
 		from member
 		where id=#{id}
@@ -47,5 +53,11 @@
 		set token = #{token, jdbcType=VARCHAR}
 		where id = #{userId}
 	</update>
+
+	<select id="memberIdById" parameterType="string" resultType="long">
+		select member_id
+		from member
+		where id=#{id}
+	</select>
 
 </mapper>

--- a/src/main/resources/mapper/message.xml
+++ b/src/main/resources/mapper/message.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+</beans>

--- a/src/main/resources/mapper/message.xml
+++ b/src/main/resources/mapper/message.xml
@@ -1,6 +1,30 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
-</beans>
+<mapper namespace="com.jida.mapper.MessageMapper">
+
+    <resultMap type="message" id="message">
+        <result column="message_id" property="messageId"/>
+        <result column="content" property="content"/>
+        <result column="created_at" property="createdAt"/>
+        <result column="room_id" property="messageRoom.roomId"/>
+        <result column="member_id" property="member.memberId"/>
+
+        <association property="messageRoom" javaType="com.jida.domain.MessageRoom">
+            <result column="room_id" property="roomId"/>
+        </association>
+
+        <association property="member" javaType="com.jida.domain.Member">
+            <result column="member_id" property="memberId"/>
+            <result column="nickname" property="nickname"/>
+        </association>
+
+    </resultMap>
+
+    <insert id="saveMessage" parameterType="message">
+        insert into message (content, room_id, member_id)
+        values (#{content}, #{messageRoom.roomId}, #{member.memberId})
+    </insert>
+
+</mapper>

--- a/src/main/resources/mapper/messageRoom.xml
+++ b/src/main/resources/mapper/messageRoom.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+</beans>

--- a/src/main/resources/mapper/messageRoom.xml
+++ b/src/main/resources/mapper/messageRoom.xml
@@ -1,6 +1,41 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
-</beans>
+<mapper namespace="com.jida.mapper.MessageRoomMapper">
+
+    <resultMap type="messageRoom" id="messageRoom">
+        <result column="room_id" property="roomId"/>
+        <result column="created_at" property="createdAt"/>
+        <result column="sender" property="sender.memberId"/>
+        <result column="receiver" property="receiver.memberId"/>
+
+        <association property="sender" javaType="com.jida.domain.Member">
+
+        </association>
+
+        <association property="receiver" javaType="com.jida.domain.Member">
+
+        </association>
+
+    </resultMap>
+    <insert id="saveMessageRoom" parameterType="messageRoom" useGeneratedKeys="true" keyProperty="roomId">
+        insert into message_room (sender, receiver)
+        values (#{sender.memberId}, #{receiver.memberId})
+    </insert>
+
+    <select id="findById" parameterType="long" resultMap="messageRoom">
+        select *
+        from message_room
+        where room_id = #{roomId}
+    </select>
+
+    <select id="findByMembers" parameterType="map" resultMap="messageRoom">
+        select *
+        from message_room
+        where (sender = #{sendMemberId} and receiver = #{receiveMemberId})
+        or (sender = #{receiveMemberId} and receiver = #{sendMemberId})
+    </select>
+
+
+</mapper>


### PR DESCRIPTION
1. 쪽지 전송하는 기능 추가
2. 쪽지 답장하는 기능 추가
3. 기존 JWTUtil에서는 토큰으로 로그인아이디(ex. ssafy)를 받았는데 pk값인 id를 받는걸로 수정했습니다.
   4. savePost에 로그인아이디 넣던 부분 Pkid로 수정
   5. member xml 수정

3~5 번때문에 뻘짓 정말 많이해서 이렇게 고쳤다 저렇게 고쳤다 다시 이렇게 고쳤따 시간을 날려버린 하루 ... 울고싶다 . . . . .

closed #67 