### PR TITLE
[FIX, FEAT] 유저정보 수정, 게시글 업데이트 수정, 댓글 전체조회 수정

### DIFF
--- a/src/main/java/com/jida/constants/ExceptionCode.java
+++ b/src/main/java/com/jida/constants/ExceptionCode.java
@@ -21,6 +21,7 @@ public enum ExceptionCode {
     FORBIDDEN_ACCESS(FORBIDDEN, "허용되지 않은 접근입니다."),
     RE_COMMENT_ONLY(FORBIDDEN, "답글의 답글은 불가능 합니다."),
     COMMENT_CANT_DELETE(FORBIDDEN, "해당 댓글의 작성자만 삭제 가능합니다."),
+    POST_CANT_DELETE(FORBIDDEN, "해당 글의 작성자만 삭제 가능합니다."),
     MESSAGE_DENIED(FORBIDDEN, "쪽지를 전송할 수 없습니다."),
 
     /* 404 - 찾을 수 없는 리소스 */

--- a/src/main/java/com/jida/controller/CommentController.java
+++ b/src/main/java/com/jida/controller/CommentController.java
@@ -8,6 +8,8 @@ import com.jida.dto.res.comment.CommentListResponseDto;
 import com.jida.dto.res.comment.CommentResponse;
 import com.jida.exception.CustomException;
 import com.jida.service.CommentService;
+import com.jida.util.JWTUtil;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -27,24 +29,27 @@ import static com.jida.constants.SuccessCode.COMMENT_SAVE_SUCCESS;
 public class CommentController {
 
     private final CommentService commentService;
-
+    private final JWTUtil jwtUtil;
     @PostMapping
     public ResponseEntity<CommentResponse> saveComment(@RequestParam Long postId,
                                                        @RequestParam(required = false) Long parentId,
-                                                       @Valid @RequestBody CommentSaveRequestDto commentSaveRequestDto) {
-        commentService.save(postId, parentId, commentSaveRequestDto);
+                                                       @Valid @RequestBody CommentSaveRequestDto commentSaveRequestDto, HttpServletRequest request) {
+        long memberId = jwtUtil.getUserId(request.getHeader("Authorization"));
+        commentService.save(memberId, postId, parentId, commentSaveRequestDto);
         return CommentResponse.newResponse(COMMENT_SAVE_SUCCESS);
     }
 
     @GetMapping("/{postId}")
-    public ResponseEntity<CommentListResponse> findAll(@PathVariable Long postId) {
-        CommentListResponseDto responseDto = commentService.findAll(postId);
+    public ResponseEntity<CommentListResponse> findAll(@PathVariable Long postId, HttpServletRequest request) {
+        long memberId = jwtUtil.getUserId(request.getHeader("Authorization"));
+        CommentListResponseDto responseDto = commentService.findAll(memberId, postId);
         return CommentListResponse.newResponse(COMMENT_LIST_SUCCESS, responseDto);
     }
 
     @DeleteMapping("/{postId}/{commentId}")
-    public ResponseEntity<CommentResponse> delete(@PathVariable Long postId, @PathVariable Long commentId) {
-        commentService.delete(postId, commentId);
+    public ResponseEntity<CommentResponse> delete(@PathVariable Long postId, @PathVariable Long commentId, HttpServletRequest request) {
+        long memberId = jwtUtil.getUserId(request.getHeader("Authorization"));
+        commentService.delete(memberId, postId, commentId);
         return CommentResponse.newResponse(COMMENT_DELETE_SUCCESS);
     }
 }

--- a/src/main/java/com/jida/controller/MemberController.java
+++ b/src/main/java/com/jida/controller/MemberController.java
@@ -148,8 +148,9 @@ public class MemberController {
 			@RequestParam(name = "order", defaultValue = "latest") String order,
 			@RequestParam(name = "boardId", defaultValue = "0") long boardId,
 			@RequestParam(name = "pageIndex", defaultValue = "1") int pageIndex,
-			@RequestParam(name = "pageSize", defaultValue = "10") int pageSize) {
-		PostListResponseDto postListResponseDto = postService.showScrap(order, boardId, pageIndex, pageSize);
+			@RequestParam(name = "pageSize", defaultValue = "10") int pageSize, HttpServletRequest request) {
+		long memberId = jwtUtil.getUserId(request.getHeader("Authorization"));
+		PostListResponseDto postListResponseDto = postService.showScrap(memberId,order, boardId, pageIndex, pageSize);
 		return PostListResponse.newResponse(SCRAP_READ_SUCCESS ,postListResponseDto);
 	}
 }

--- a/src/main/java/com/jida/controller/PostController.java
+++ b/src/main/java/com/jida/controller/PostController.java
@@ -59,16 +59,18 @@ public class PostController {
 
     @PutMapping("/{postId}")
     public ResponseEntity<PostDetailResponse> modifyPost(@PathVariable("postId") long postId,
-                                                         @RequestBody PostSaveRequestDto postSaveRequestDto) {
-        long updatedPostId = postService.modifyPost(postId, postSaveRequestDto);
+                                                         @RequestBody PostSaveRequestDto postSaveRequestDto,HttpServletRequest request) {
+        long memberId = jwtUtil.getUserId(request.getHeader("Authorization"));
+        long updatedPostId = postService.modifyPost(memberId, postId, postSaveRequestDto);
         PostDetailResponseDto responseDto = postService.viewPost(updatedPostId);
 
         return PostDetailResponse.newResponse(POST_UPDATE_SUCCESS, responseDto);
     }
 
     @DeleteMapping("/{postId}")
-    public ResponseEntity<PostResponse> deletePost(@PathVariable("postId") long postId) {
-        postService.deletePost(postId);
+    public ResponseEntity<PostResponse> deletePost(@PathVariable("postId") long postId, HttpServletRequest request) {
+        long memberId = jwtUtil.getUserId(request.getHeader("Authorization"));
+        postService.deletePost(memberId, postId);
         return PostResponse.newResponse(POST_DELETE_SUCCESS);
     }
 
@@ -84,8 +86,9 @@ public class PostController {
     }
 
     @PostMapping("/{postId}/like")
-    public ResponseEntity<PostResponse> postLike(@PathVariable Long postId) {
-        boolean response = postService.clickPostLike(postId);
+    public ResponseEntity<PostResponse> postLike(@PathVariable Long postId, HttpServletRequest request) {
+        long memberId = jwtUtil.getUserId(request.getHeader("Authorization"));
+        boolean response = postService.clickPostLike(memberId, postId);
         if (response) {
 			return PostResponse.newResponse(POST_LIKE_SUCCESS);
         }
@@ -93,8 +96,9 @@ public class PostController {
     }
 
     @PostMapping("/{postId}/scrap")
-    public ResponseEntity<PostResponse> postScrap(@PathVariable Long postId) {
-        boolean response = postService.clickPostScrap(postId);
+    public ResponseEntity<PostResponse> postScrap(@PathVariable Long postId, HttpServletRequest request) {
+        long memberId = jwtUtil.getUserId(request.getHeader("Authorization"));
+        boolean response = postService.clickPostScrap(memberId, postId);
         if (response) {
             return PostResponse.newResponse(POST_SCRAP_SUCCESS);
         }

--- a/src/main/java/com/jida/domain/Post.java
+++ b/src/main/java/com/jida/domain/Post.java
@@ -5,6 +5,7 @@ import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 
 @Getter
+@Setter
 public class Post {
 	private long postId;
 	private String title;

--- a/src/main/java/com/jida/service/CommentService.java
+++ b/src/main/java/com/jida/service/CommentService.java
@@ -6,9 +6,9 @@ import com.jida.dto.res.comment.CommentListResponseDto;
 import java.util.List;
 
 public interface CommentService {
-    void save(Long postId, Long parentId, CommentSaveRequestDto commentSaveRequestDto);
+    void save(long memberId, Long postId, Long parentId, CommentSaveRequestDto commentSaveRequestDto);
 
-    CommentListResponseDto findAll(Long postId);
+    CommentListResponseDto findAll(long memberId,Long postId);
 
-    void delete(Long postId, Long commentId);
+    void delete(long memberId, Long postId, Long commentId);
 }

--- a/src/main/java/com/jida/service/CommentServiceImpl.java
+++ b/src/main/java/com/jida/service/CommentServiceImpl.java
@@ -14,6 +14,7 @@ import com.jida.dto.res.comment.CommentListResponseDto;
 import com.jida.dto.res.comment.CommentListResponseDto.CommentList;
 import com.jida.exception.CustomException;
 import com.jida.mapper.CommentMapper;
+import com.jida.mapper.MemberMapper;
 import com.jida.mapper.PostMapper;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -24,11 +25,12 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class CommentServiceImpl implements CommentService {
     private final CommentMapper commentMapper;
+    private final MemberMapper memberMapper;
     private final PostMapper postMapper;
 
     @Override
-    public void save(Long postId, Long parentId, CommentSaveRequestDto commentSaveRequestDto) {
-        Member member = getMember();
+    public void save(long memberId, Long postId, Long parentId, CommentSaveRequestDto commentSaveRequestDto) {
+        Member member = getMember(memberId);
         Post post = postMapper.findById(postId)
                 .orElseThrow(() -> new CustomException(POST_NOT_FOUND));
 
@@ -48,10 +50,10 @@ public class CommentServiceImpl implements CommentService {
     }
 
     @Override
-    public CommentListResponseDto findAll(Long postId) {
+    public CommentListResponseDto findAll(long memberId, Long postId) {
         Post post = postMapper.findById(postId)
                 .orElseThrow(() -> new CustomException(POST_NOT_FOUND));
-        Member member = getMember();
+        Member member = getMember(memberId);
 
         List<CommentList> comments = commentMapper.findAll(postId).stream()
                 .map(comment -> CommentList.of(comment,
@@ -62,8 +64,8 @@ public class CommentServiceImpl implements CommentService {
     }
 
     @Override
-    public void delete(Long postId, Long commentId) {
-        Member member = getMember();
+    public void delete(long memberId, Long postId, Long commentId) {
+        Member member = getMember(memberId);
         Post post = postMapper.findById(postId)
                 .orElseThrow(() -> new CustomException(POST_NOT_FOUND));
         Comment comment = commentMapper.findById(commentId)
@@ -77,14 +79,8 @@ public class CommentServiceImpl implements CommentService {
         postMapper.diffCommentCnt(postId);
     }
 
-    //TODO: jwt 토큰 구현 시 변경 필요
-    private Member getMember() {
-        Member member = new Member();
-        member.setMemberId(1L);
-        member.setEmail("ssafy@ssafy.com");
-        member.setId("ssafy");
-        member.setPassword("1234");
-        member.setNickname("김싸피");
-        return member;
+
+    private Member getMember(long memberId) {
+        return memberMapper.findById(memberId);
     }
 }

--- a/src/main/java/com/jida/service/PostService.java
+++ b/src/main/java/com/jida/service/PostService.java
@@ -14,9 +14,9 @@ public interface PostService {
 	long writePost(long memberId, PostSaveRequestDto postSaveRequestDto);
 	void updateHit(long postId);
 	PostDetailResponseDto viewPost(long postId);
-	long modifyPost(long postId, PostSaveRequestDto postSaveRequestDto);
-	void deletePost(long postId);
-	boolean clickPostLike(Long postId);
-	boolean clickPostScrap(Long postId);
-	PostListResponseDto showScrap(String order, long boardId, int pageIndex, int pageSize);
+	long modifyPost(long memberId,long postId, PostSaveRequestDto postSaveRequestDto);
+	void deletePost(long memberId,long postId);
+	boolean clickPostLike(long memberId,Long postId);
+	boolean clickPostScrap(long memberId,Long postId);
+	PostListResponseDto showScrap(long memberId,String order, long boardId, int pageIndex, int pageSize);
 }

--- a/src/main/resources/mapper/comment.xml
+++ b/src/main/resources/mapper/comment.xml
@@ -13,6 +13,7 @@
         <result column="create_at" property="createdAt"/>
 
         <association property="member" javaType="member">
+            <result column="member_id" property="memberId"/>
             <result column="nickname" property="nickname"/>
         </association>
     </resultMap>

--- a/src/main/resources/mapper/post.xml
+++ b/src/main/resources/mapper/post.xml
@@ -48,7 +48,7 @@
 
 	<update id="updatePost" parameterType="post">
 		update post
-		set title = #{title}, content = #{content}, board_id = #{boardId}
+		set title = #{title}, content = #{content}, board_id = #{board.boardId}
 		where post_id = #{postId}
 	</update>
 


### PR DESCRIPTION
1. Post 에 setter를 다시 추가했습니다. -> post update 할 때 setPostId가 없어서 수정이 안되는 현상 발견 !
2. 댓글 전체조회시 작성자 MemberId가 안들어오는것 발견 ! -> 쿼리문 수정 해서 반영했습니다.
3. 컨트롤러, 서비스단에 로그인한 유저 memberId 넘기는 코드로 다 수정했습니다.. 

closed #78 